### PR TITLE
Pin Ansible to 2.0.2.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN wget -q --no-check-certificate --no-cookies --header "Cookie: oraclelicense=
     rm jdk-8u51-linux-x64.rpm
 
 # install pip dependencies
-ENV ANSIBLE_VERSION=2.1.1.0
+# FIXME ansible is broken for ECS deploys in newer versions than this
+ENV ANSIBLE_VERSION=2.0.2.0
 RUN pip install ansible==$ANSIBLE_VERSION boto boto3 awscli setuptools --upgrade > /dev/null
 
 # install docker


### PR DESCRIPTION
Versions after this break ECS deployments due to a \xe2 character
snuck into the source code in ecs_service.py. It's terrible.

See: http://jenkins.hautelook.net/jenkins/job/workflow-qa-deploy-docker/209/console